### PR TITLE
Fix heredoc variable expansion

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -177,6 +177,7 @@ typedef struct s_redir_ls
 {
 	int					type;
 	char				*filename;
+	int					quoted;
 	struct s_redir_ls	*next;
 }	t_redir_ls;
 
@@ -298,10 +299,18 @@ int			cd_too_many_args(t_ast *data);
 int			open_infile(char *path);
 int			open_outfile(char *path, int type);
 void		create_intermediate_outfile(char *path, int type);
-void		cleanup_heredoc_files(t_ast *data);
-int			handle_line(int fd, char *line, char *delim);
-int			run_heredoc_loop(int fd, char *delim);
-int			fork_heredoc(int fd, char *delim);
+void	cleanup_heredoc_files(t_ast *data);
+
+typedef struct s_hdinfo
+{
+	char			*delim;
+	int			quoted;
+	t_ast		*data;
+}		t_hdinfo;
+
+int				handle_line(int fd, char *line, t_hdinfo *info);
+int				run_heredoc_loop(int fd, t_hdinfo *info);
+int				fork_heredoc(int fd, t_hdinfo *info);
 int			setup_heredoc_filename(t_ast *data, t_ast *node, char *tmp);
 void		update_last_exit_status(t_ctx *ctx, int status);
 int			gles(t_ctx *ctx);
@@ -521,14 +530,14 @@ int			is_redirection_token(t_token_type type);
 int			set_command_name(t_ast *cmd_node, char *name);
 int			add_command_arg(t_ast *cmd_node, char *arg);
 int			looks_like_subshell(t_token *curr);
-t_redir_ls	*create_redir_node(int type, char *filename);
+t_redir_ls	*create_redir_node(int type, char *filename, int quoted);
 t_ast		*parse_command(t_token **tokens);
 t_ast		*parse_logic_sequence(t_token **tokens);
 t_ast		*create_ast_node(t_ast_type type, t_token *token);
 void		free_ast(t_ast *node);
 t_ast		*parse_simple_commands(t_token **tokens);
 t_commands	*create_command_struct(void);
-int			add_redirection(t_commands *cmd, int type, char *filename);
+int			add_redirection(t_commands *cmd, int type, char *filename, int quoted);
 char		**expand_command_args(char **temp_args, int temp_count);
 t_ast		*create_command_node(t_token *start, int word_count);
 void		skip_tree_whitespaces(t_token **tokens);

--- a/src/execution/main_exec/exec_word/execute_word.c
+++ b/src/execution/main_exec/exec_word/execute_word.c
@@ -39,7 +39,8 @@ int	create_heredoc_file(t_ast *data, t_redir_ls *redir)
 	fd = open_unique_tmp(ft_strcpy(tmp, HEREDOC_TEMPLATE));
 	if (fd < 0)
 		return (perror("open_unique_tmp"), 0);
-	status = fork_heredoc(fd, redir->filename);
+    t_hdinfo info = {redir->filename, redir->quoted, data};
+    status = fork_heredoc(fd, &info);
 	close(fd);
 	if (status != 0)
 	{

--- a/src/execution/redirections/redirection_utils.c
+++ b/src/execution/redirections/redirection_utils.c
@@ -12,25 +12,47 @@
 
 #include "minishell.h"
 
-int	handle_line(int fd, char *line, char *delim)
+static void write_expanded(int fd, char *line, t_ast *data)
+{
+    t_args  arg;
+    char    *expanded;
+
+    arg = (t_args){.argc = g_ctx->argc - 1, .argv = g_ctx->argv + 1,
+            .exit_status = gles(g_ctx)};
+    expanded = parse_env(line, data->env_list, &arg);
+    if (expanded)
+    {
+            ft_putendl_fd(expanded, fd);
+            free(expanded);
+    }
+    else
+            ft_putendl_fd(line, fd);
+}
+
+int     handle_line(int fd, char *line, t_hdinfo *info)
 {
 	if (!line)
 	{
 		ft_putstr_fd("bash: warning: here-document delimited by ",
 			STDERR_FILENO);
 		ft_putstr_fd("end-of-file (wanted `", STDERR_FILENO);
-		ft_putstr_fd(delim, STDERR_FILENO);
+		ft_putstr_fd(info->delim, STDERR_FILENO);
 		ft_putendl_fd("')", STDERR_FILENO);
 		return (2);
 	}
-	if (ft_strcmp(line, delim) == 0)
-		return (1);
-	ft_putendl_fd(line, fd);
-	free(line);
+        if (ft_strcmp(line, info->delim) == 0)
+                return (1);
+        if (!info->quoted)
+        {
+                write_expanded(fd, line, info->data);
+        }
+        else
+                ft_putendl_fd(line, fd);
+        free(line);
 	return (0);
 }
 
-int	run_heredoc_loop(int fd, char *delim)
+int     run_heredoc_loop(int fd, t_hdinfo *info)
 {
 	char	*line;
 	int		status;
@@ -40,7 +62,7 @@ int	run_heredoc_loop(int fd, char *delim)
 	while (1)
 	{
 		line = readline("> ");
-		status = handle_line(fd, line, delim);
+		status = handle_line(fd, line, info);
 		if (status == 1)
 		{
 			free(line);
@@ -52,7 +74,7 @@ int	run_heredoc_loop(int fd, char *delim)
 	return (0);
 }
 
-int	fork_heredoc(int fd, char *delim)
+int     fork_heredoc(int fd, t_hdinfo *info)
 {
 	pid_t	pid;
 	int		status;
@@ -60,7 +82,7 @@ int	fork_heredoc(int fd, char *delim)
 
 	pid = fork();
 	if (pid == 0)
-		exit(run_heredoc_loop(fd, delim));
+		exit(run_heredoc_loop(fd, info));
 	waitpid(pid, &status, 0);
 	if (WIFSIGNALED(status))
 	{

--- a/src/tree/parse_commands.c
+++ b/src/tree/parse_commands.c
@@ -35,7 +35,7 @@ t_ast	*init_command_node(t_token *start, int word_count)
 	return (node);
 }
 
-t_redir_ls	*create_redir_node(int type, char *filename)
+t_redir_ls	*create_redir_node(int type, char *filename, int quoted)
 {
 	t_redir_ls	*redir;
 
@@ -44,6 +44,7 @@ t_redir_ls	*create_redir_node(int type, char *filename)
 		return (NULL);
 	redir->type = type;
 	redir->filename = ft_strdup(filename);
+        redir->quoted = quoted;
 	if (!redir->filename)
 	{
 		free(redir);
@@ -78,7 +79,7 @@ static char	*expand_redir_filename(const char *pattern)
 	return (result);
 }
 
-int	add_redirection(t_commands *cmd, int type, char *filename)
+int	add_redirection(t_commands *cmd, int type, char *filename, int quoted)
 {
 	t_redir_ls	*new_redir;
 	t_redir_ls	*curr;
@@ -89,10 +90,10 @@ int	add_redirection(t_commands *cmd, int type, char *filename)
 	expanded = expand_redir_filename(filename);
 	if (!expanded)
 		return (0);
-	new_redir = create_redir_node(type, expanded);
-	free(expanded);
-	if (!new_redir)
-		return (0);
+        new_redir = create_redir_node(type, expanded, quoted);
+        free(expanded);
+        if (!new_redir)
+                return (0);
 	if (!cmd->redirections)
 	{
 		cmd->redirections = new_redir;

--- a/src/tree/parse_redir.c
+++ b/src/tree/parse_redir.c
@@ -49,7 +49,7 @@ static int	handle_single_redirection(t_token **tokens, t_commands *cmd)
 		return (0);
 	if (!validate_redirection_tokens(tokens, &redir_token, &filename_token))
 		return (0);
-	if (!add_redirection(cmd, redir_token->type, filename_token->value))
+        if (!add_redirection(cmd, redir_token->type, filename_token->value, (filename_token->quotes.in_single_quotes || filename_token->quotes.in_double_quotes)))
 		return (0);
 	*tokens = (*tokens)->next;
 	return (1);


### PR DESCRIPTION
## Summary
- store heredoc delimiter quoting info
- expand environment variables in heredocs when delimiter is not quoted
- plumb quoted flag through redirection helpers

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68603d289460832e810d49ae6efb1bb0