### PR TITLE
Fix quoting for concatenated commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,9 @@ SRCS = $(SRC)main.c $(SRC)main_utils.c $(TREE)tree.c $(TOKENIZE)tokenize.c \
 	   $(EXEC_ENV)env_utils_2.c $(EXEC_ENV)env_export.c $(EXEC_ENV)env_unset.c $(EXEC_ENV)export_utils.c \
 	   $(TREE)parse_wildcards.c $(ENV)env_utils.c $(ENV)env_utils_1.c $(TREE)parse_wildcards_utils.c\
 	   $(TOKENIZE)tokenize_assignment.c $(PARENTHESIS)assignment_paren.c $(TREE)parse_parenthesis.c\
-	   $(PARENTHESIS)parenthesis_utils_3.c $(TREE)tree_utils_2.c $(ENV)env_utils_2.c\
-	   $(TREE)parse_utils_1.c\
+$(PARENTHESIS)parenthesis_utils_3.c $(TREE)tree_utils_2.c $(ENV)env_utils_2.c\
+$(TREE)parse_utils_1.c \
+$(PARSE_UTILS)merge_words.c\
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -554,6 +554,7 @@ int			ft_isspace(int num);
 void		clear_data(t_env **data, char **envp);
 void		handle_signal(t_ctx *ctx);
 void		free_2darray(char **array);
+void            merge_adjacent_words(t_token *tokens);
 int			execute_tree(t_ast *data, t_ast *tree);
 
 // Main functions

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -185,15 +185,16 @@ void	handle_input(char *input, t_env *env_list, t_ctx *ctx)
 			return ;
 		arg = (t_args){.argc = ctx->argc - 1, .argv = ctx->argv,
 			.exit_status = gles(ctx)};
-		expandable = expand_and_tokenize(processed, env_list, &arg, &tokens);
-		free(processed);
-		if (!expandable)
-			return ;
-		if (!validation(tokens))
-		{
-			free(expandable);
-			update_last_exit_status(ctx, 2);
-			return ;
+                expandable = expand_and_tokenize(processed, env_list, &arg, &tokens);
+                free(processed);
+                if (!expandable)
+                        return ;
+                merge_adjacent_words(tokens);
+                if (!validation(tokens))
+                {
+                        free(expandable);
+                        update_last_exit_status(ctx, 2);
+                        return ;
 		}
 		execute_input(tokens, env_list, expandable, ctx);
 	}

--- a/src/parse/utils/merge_words.c
+++ b/src/parse/utils/merge_words.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   merge_words.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/17 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2025/07/17 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../../include/minishell.h"
+
+static void merge_two_tokens(t_token *curr, t_token *next)
+{
+    char    *joined;
+
+    joined = ft_strjoin(curr->value, next->value);
+    if (!joined)
+        return ;
+    free(curr->value);
+    curr->value = joined;
+    if (next->expandable)
+        curr->expandable = next->expandable;
+    if (next->quotes.in_double_quotes)
+        curr->quotes.in_double_quotes = true;
+    if (next->quotes.in_single_quotes)
+        curr->quotes.in_single_quotes = true;
+    curr->next = next->next;
+    free(next->value);
+    free(next);
+}
+
+void    merge_adjacent_words(t_token *tokens)
+{
+    t_token *curr;
+
+    curr = tokens;
+    while (curr && curr->next)
+    {
+        if (curr->type == TOKEN_WORD && curr->next->type == TOKEN_WORD)
+        {
+            merge_two_tokens(curr, curr->next);
+            continue ;
+        }
+        curr = curr->next;
+    }
+}


### PR DESCRIPTION
## Summary
- merge consecutive word tokens so that quoted segments combine
- expose merge function in header and build system
- apply merging during input handling to match bash behavior

## Testing
- `make`
- run minishell with `./ls`, `"./"ls`, `./""ls`, and `"./"''"ls"`

------
https://chatgpt.com/codex/tasks/task_e_6860619ffc5c832e9ea81e57f5f3963c