### PR TITLE
Fix heredoc delimiter processing

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -206,6 +206,7 @@ typedef struct s_args
 	int				i;
 	char			*old_result;
 	char			*temp;
+        int                             in_heredoc;
 }	t_args;
 
 typedef struct s_expand_wild

--- a/src/execution/redirections/redirection_utils.c
+++ b/src/execution/redirections/redirection_utils.c
@@ -17,8 +17,8 @@ static void	write_expanded(int fd, char *line, t_ast *data)
 	t_args	arg;
 	char	*expanded;
 
-	arg = (t_args){.argc = g_ctx->argc - 1, .argv = g_ctx->argv + 1,
-		.exit_status = gles(g_ctx)};
+       arg = (t_args){.argc = g_ctx->argc - 1, .argv = g_ctx->argv + 1,
+                       .exit_status = gles(g_ctx), .in_heredoc = 0};
 	expanded = parse_env(line, data->env_list, &arg);
 	if (expanded)
 	{

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -183,8 +183,8 @@ void	handle_input(char *input, t_env *env_list, t_ctx *ctx)
 		processed = preprocess_double_parenthesis(input);
 		if (!processed)
 			return ;
-		arg = (t_args){.argc = ctx->argc - 1, .argv = ctx->argv,
-			.exit_status = gles(ctx)};
+               arg = (t_args){.argc = ctx->argc - 1, .argv = ctx->argv,
+                               .exit_status = gles(ctx), .in_heredoc = 0};
 		expandable = expand_and_tokenize(processed, env_list, &arg, &tokens);
 		free(processed);
 		if (!expandable)

--- a/src/parse/env/convert_env.c
+++ b/src/parse/env/convert_env.c
@@ -12,6 +12,29 @@
 
 #include "../../../include/minishell.h"
 
+static void     append_segment(t_args *p, int end)
+{
+       char    *tmp;
+       char    *new_res;
+
+       if (end > p->start)
+       {
+               tmp = ft_substr(p->input, p->start, end - p->start);
+               if (!tmp)
+                       return ;
+               new_res = ft_strjoin(p->result, tmp);
+               free(tmp);
+               if (!new_res)
+               {
+                       free(p->result);
+                       p->result = NULL;
+                       return ;
+               }
+               free(p->result);
+               p->result = new_res;
+       }
+}
+
 t_env	*create_copy_env_node(t_env *original)
 {
 	t_env	*env_node;
@@ -40,29 +63,57 @@ t_env	*create_copy_env_node(t_env *original)
 	return (env_node);
 }
 
-void	process_env_var(t_args *parse, t_env *env_list, char *input)
+
+void    process_env_var(t_args *parse, t_env *env_list, char *input)
 {
-	int		old_i;
+        int             old_i;
 
-	if (quotes(input, parse->i, parse))
-	{
-		parse->i++;
-		return ;
-	}
-	if (input[parse->i] == '$' && input[parse->i + 1]
-		&& input[parse->i + 1] != '\'' && input[parse->i + 1] != ' '
-		&& input[parse->i + 1] != '"')
-	{
-		old_i = parse->i;
-		parse->result = handle_env_part(parse, &parse->i, env_list);
-		if (parse->i == old_i)
-			parse->i++;
-		parse->start = parse->i;
-	}
-	else
-		parse->i++;
+        if (!parse->in_heredoc && !parse->single_quotes && !parse->double_quotes
+                && input[parse->i] == '<' && input[parse->i + 1] == '<')
+        {
+                append_segment(parse, parse->i);
+                parse->start = parse->i;
+                parse->in_heredoc = 1;
+                parse->i += 2;
+                return ;
+        }
+        if (parse->in_heredoc)
+        {
+                if (quotes(input, parse->i, parse))
+                {
+                        parse->i++;
+                        return ;
+                }
+                if (!parse->single_quotes && !parse->double_quotes
+                        && (ft_isspace(input[parse->i]) || is_operator(input[parse->i])
+                                || input[parse->i] == '\0'))
+                {
+                        append_segment(parse, parse->i);
+                        parse->start = parse->i;
+                        parse->in_heredoc = 0;
+                        return ;
+                }
+                parse->i++;
+                return ;
+        }
+        if (quotes(input, parse->i, parse))
+        {
+                parse->i++;
+                return ;
+        }
+        if (input[parse->i] == '$' && input[parse->i + 1]
+                && input[parse->i + 1] != '\'' && input[parse->i + 1] != ' '
+                && input[parse->i + 1] != '"')
+        {
+                old_i = parse->i;
+                parse->result = handle_env_part(parse, &parse->i, env_list);
+                if (parse->i == old_i)
+                        parse->i++;
+                parse->start = parse->i;
+        }
+        else
+                parse->i++;
 }
-
 t_env	*deep_copy_env_list(t_env *env_list)
 {
 	t_env	*new_head;

--- a/src/parse/env/env_parsing_utils.c
+++ b/src/parse/env/env_parsing_utils.c
@@ -128,8 +128,8 @@ char	*parse_env(char *input, t_env *env_list, t_args *arg)
 {
 	t_args		parse;
 
-	parse = (t_args){arg->argc, arg->argv, arg->exit_status, input, 0,
-		ft_strdup(""), 0, 0, 0, 0, NULL, NULL};
+       parse = (t_args){arg->argc, arg->argv, arg->exit_status, input, 0,
+               ft_strdup(""), 0, 0, 0, 0, NULL, NULL, 0};
 	if (!parse.result)
 		return (NULL);
 	while (input[parse.i] && parse.i < ft_strlen(input))


### PR DESCRIPTION
## Summary
- preserve heredoc delimiters when expanding environment variables
- track heredoc mode in parsing utilities
- initialize new `in_heredoc` field when expanding

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686060bef918832e8b4d339afd57aeb5