### PR TITLE
Fix heredoc quoting

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -176,11 +176,16 @@ typedef struct s_state
 
 typedef struct s_redir_ls
 {
-	int					type;
-	char				*filename;
-	int					quoted;
-	struct s_redir_ls	*next;
-}	t_redir_ls;
+        int                                     type;
+        char                            *filename;
+        /* quoted values:
+        ** 0 - not quoted
+        ** 1 - single quoted
+        ** 2 - double quoted
+        */
+        int                                     quoted;
+        struct s_redir_ls       *next;
+}       t_redir_ls;
 
 typedef struct s_command
 {

--- a/src/execution/redirections/redirection_utils.c
+++ b/src/execution/redirections/redirection_utils.c
@@ -34,22 +34,28 @@ static char     *read_line_fd(int fd)
         line[len] = '\0';
         return (line);
 }
-static void	write_expanded(int fd, char *line, t_ast *data)
+static void     write_expanded(int fd, char *line, t_ast *data)
 {
-	t_args	arg;
-	char	*expanded;
+        t_args  arg;
+        char    *tmp;
+        char    *expanded;
 
-	arg = (t_args){.argc = g_ctx->argc - 1, .argv = g_ctx->argv + 1,
-		.exit_status = gles(g_ctx)};
-	expanded = parse_env(line, data->env_list, &arg);
-	if (expanded)
-	{
-		ft_putendl_fd(expanded, fd);
-		free(expanded);
-	}
-	else
-		ft_putendl_fd(line, fd);
+        arg = (t_args){.argc = g_ctx->argc - 1, .argv = g_ctx->argv + 1,
+                .exit_status = gles(g_ctx)};
+        tmp = expand_tilde(line, data->env_list);
+        if (!tmp)
+                tmp = ft_strdup(line);
+        expanded = parse_env(tmp, data->env_list, &arg);
+        if (expanded)
+        {
+                ft_putendl_fd(expanded, fd);
+                free(expanded);
+        }
+        else
+                ft_putendl_fd(tmp, fd);
+        free(tmp);
 }
+
 
 int	handle_line(int fd, char *line, t_hdinfo *info)
 {

--- a/src/tree/parse_redir.c
+++ b/src/tree/parse_redir.c
@@ -34,8 +34,13 @@ static int      collect_delimiter(t_token **tokens, char **value, int *quoted)
                 if (!tmp)
                         return (0);
                 res = tmp;
-                if (curr->quotes.in_single_quotes || curr->quotes.in_double_quotes)
-                        *quoted = 1;
+                if (*quoted == 0)
+                {
+                        if (curr->quotes.in_single_quotes)
+                                *quoted = 1;
+                        else if (curr->quotes.in_double_quotes)
+                                *quoted = 2;
+                }
                 curr = curr->next;
         }
         *tokens = curr;

--- a/tests/heredoc_quoted.sh
+++ b/tests/heredoc_quoted.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Test heredoc parsing with quoted delimiters and nested pipelines
+set -e
+
+# Quoted delimiter should disable expansions
+printf 'cat << "$USER"\nwhy\nnot\n$USER\nexit\n' | ./minishell
+
+# Nested pipeline heredocs
+printf 'ls | cat << stop | ls -la | cat << stop1 | ls | cat << stop2 | ls -la | cat << stop3\n$USER\nad\nas $HOME\nstop\nawd\nwf$PWDdqwdwqd\nstop1\ndas\ndas\nstop2\ndsq\nwd\nwf$PWDdqwdwqd\nstop3\nexit\n' | ./minishell


### PR DESCRIPTION
## Summary
- track if heredoc delimiters were single- or double-quoted
- skip variable and tilde expansion for quoted heredocs
- add regression tests for quoted heredocs and nested pipelines

## Testing
- `make`
- `./tests/heredoc_quoted.sh > /tmp/test.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_686118aa59c0832e947f39a4b87863f1